### PR TITLE
Fix outputs - round 2

### DIFF
--- a/ghedesigner/tests/test_find_design_bi_polygon.py
+++ b/ghedesigner/tests/test_find_design_bi_polygon.py
@@ -12,7 +12,7 @@ from ghedesigner.borehole_heat_exchangers import SingleUTube, MultipleUTube, Coa
 from ghedesigner.design import DesignBiRectangleConstrained
 from ghedesigner.geometry import GeometricConstraints
 from ghedesigner.media import Pipe, Soil, Grout, GHEFluid, SimulationParameters
-from ghedesigner.output import output_design_details
+from ghedesigner.output import write_output_files
 from ghedesigner.tests.ghe_base_case import GHEBaseTest
 from ghedesigner.utilities import DesignMethod
 
@@ -174,7 +174,7 @@ class TestFindBiPolygonDesign(GHEBaseTest):
         self.log(f"Total Drilling: {bisection_search.ghe.bhe.b.H * nbh:0.1f} meters\n")
 
         # Generating Output File
-        output_design_details(
+        write_output_files(
             bisection_search,
             toc - tic,
             project_name,
@@ -182,11 +182,7 @@ class TestFindBiPolygonDesign(GHEBaseTest):
             author,
             iteration_name,
             output_directory=output_file_directory,
-            summary_file="SummaryOfResults_SU.txt",
-            csv_f_1="TimeDependentValues_SU.csv",
-            csv_f_2="BorefieldData_SU.csv",
-            csv_f_3="Loadings_SU.csv",
-            csv_f_4="GFunction_SU.csv",
+            file_suffix="_SU",
             load_method=DesignMethod.Hybrid,
         )
 
@@ -236,7 +232,7 @@ class TestFindBiPolygonDesign(GHEBaseTest):
         self.log(f"Total Drilling: {bisection_search.ghe.bhe.b.H * nbh:0.1f} meters\n")
 
         # Generating Output File
-        output_design_details(
+        write_output_files(
             bisection_search,
             toc - tic,
             project_name,
@@ -244,11 +240,7 @@ class TestFindBiPolygonDesign(GHEBaseTest):
             author,
             iteration_name,
             output_directory=output_file_directory,
-            summary_file="SummaryOfResults_DU.txt",
-            csv_f_1="TimeDependentValues_DU.csv",
-            csv_f_2="BorefieldData_DU.csv",
-            csv_f_3="Loadings_DU.csv",
-            csv_f_4="GFunction_DU.csv",
+            file_suffix="_DU",
             load_method=DesignMethod.Hybrid,
         )
 
@@ -311,7 +303,7 @@ class TestFindBiPolygonDesign(GHEBaseTest):
         self.log(f"Total Drilling: {bisection_search.ghe.bhe.b.H * nbh:0.1f} meters\n")
 
         # Generating Output File
-        output_design_details(
+        write_output_files(
             bisection_search,
             toc - tic,
             project_name,
@@ -319,10 +311,6 @@ class TestFindBiPolygonDesign(GHEBaseTest):
             author,
             iteration_name,
             output_directory=output_file_directory,
-            summary_file="SummaryOfResults_C.txt",
-            csv_f_1="TimeDependentValues_C.csv",
-            csv_f_2="BorefieldData_C.csv",
-            csv_f_3="Loadings_C.csv",
-            csv_f_4="GFunction_C.csv",
+            file_suffix="_C",
             load_method=DesignMethod.Hybrid,
         )

--- a/ghedesigner/tests/test_find_design_bi_rectangle.py
+++ b/ghedesigner/tests/test_find_design_bi_rectangle.py
@@ -11,7 +11,7 @@ from ghedesigner.borehole_heat_exchangers import SingleUTube
 from ghedesigner.design import DesignBiRectangle
 from ghedesigner.geometry import GeometricConstraints
 from ghedesigner.media import Pipe, Soil, Grout, GHEFluid, SimulationParameters
-from ghedesigner.output import output_design_details
+from ghedesigner.output import write_output_files
 from ghedesigner.tests.ghe_base_case import GHEBaseTest
 from ghedesigner.utilities import DesignMethod
 
@@ -152,7 +152,7 @@ class TestFindBiRectangleDesign(GHEBaseTest):
         # l_x_perimeter = 85.0
         # l_y_perimeter = 80.0
 
-        output_design_details(
+        write_output_files(
             bisection_search,
             toc - tic,
             project_name,
@@ -160,11 +160,7 @@ class TestFindBiRectangleDesign(GHEBaseTest):
             author,
             iteration_name,
             output_directory=output_file_directory,
-            summary_file="SummaryOfResults_SU.txt",
-            csv_f_1="TimeDependentValues_SU.txt",
-            csv_f_2="BorefieldData_SU.csv",
-            csv_f_3="Loadings_SU.csv",
-            csv_f_4="GFunction_SU.csv",
+            file_suffix="_SU",
             load_method=DesignMethod.Hybrid,
         )
         """

--- a/ghedesigner/tests/test_find_design_bi_zoned_rectangle.py
+++ b/ghedesigner/tests/test_find_design_bi_zoned_rectangle.py
@@ -11,7 +11,7 @@ from ghedesigner.borehole_heat_exchangers import SingleUTube
 from ghedesigner.design import DesignBiZoned
 from ghedesigner.geometry import GeometricConstraints
 from ghedesigner.media import Pipe, Soil, Grout, GHEFluid, SimulationParameters
-from ghedesigner.output import output_design_details
+from ghedesigner.output import write_output_files
 from ghedesigner.tests.ghe_base_case import GHEBaseTest
 from ghedesigner.utilities import DesignMethod
 
@@ -150,7 +150,7 @@ class TestFindBiZonedRectangleDesign(GHEBaseTest):
         self.log(f"Number of boreholes: {nbh}")
         self.log(f"Total Drilling: {bisection_search.ghe.bhe.b.H * nbh:0.1f} meters\n")
 
-        output_design_details(
+        write_output_files(
             bisection_search,
             toc - tic,
             project_name,
@@ -158,11 +158,7 @@ class TestFindBiZonedRectangleDesign(GHEBaseTest):
             author,
             iteration_name,
             output_directory=output_file_directory,
-            summary_file="SummaryOfResults_SU.txt",
-            csv_f_1="TimeDependentValues_SU.csv",
-            csv_f_2="BorefieldData_SU.csv",
-            csv_f_3="Loadings_SU.csv",
-            csv_f_4="GFunction_SU.csv",
+            file_suffix="_SU",
             load_method=DesignMethod.Hybrid,
         )
         """

--- a/ghedesigner/tests/test_find_design_near_square.py
+++ b/ghedesigner/tests/test_find_design_near_square.py
@@ -11,7 +11,7 @@ from ghedesigner.design import DesignNearSquare
 from ghedesigner.geometry import GeometricConstraints
 from ghedesigner.manager import GHEManager
 from ghedesigner.media import Pipe, Soil, Grout, GHEFluid, SimulationParameters
-from ghedesigner.output import output_design_details
+from ghedesigner.output import write_output_files
 from ghedesigner.tests.ghe_base_case import GHEBaseTest
 from ghedesigner.utilities import DesignMethod, length_of_side
 
@@ -53,7 +53,7 @@ class TestFindNearSquareDesign(GHEBaseTest):
         output_file_directory = self.test_outputs_directory / "DesignExampleOutput"
 
         # Generating Output File
-        output_design_details(
+        write_output_files(
             manager._search,  # TODO: Make so we don't have to access a protected method for this
             toc - tic,
             project_name,
@@ -61,11 +61,7 @@ class TestFindNearSquareDesign(GHEBaseTest):
             author,
             iteration_name,
             output_directory=output_file_directory,
-            summary_file="SummaryOfResults_SU.txt",
-            csv_f_1="TimeDependentValues_SU.csv",
-            csv_f_2="BorefieldData_SU.csv",
-            csv_f_3="Loadings_SU.csv",
-            csv_f_4="GFunction_SU.csv",
+            file_suffix="_SU",
             load_method=DesignMethod.Hybrid,
         )
 
@@ -183,7 +179,7 @@ class TestFindNearSquareDesign(GHEBaseTest):
         self.log(f"Total Drilling: {bisection_search.ghe.bhe.b.H * nbh:0.1f} meters\n")
 
         # Generating Output File
-        output_design_details(
+        write_output_files(
             bisection_search,
             toc - tic,
             project_name,
@@ -191,11 +187,7 @@ class TestFindNearSquareDesign(GHEBaseTest):
             author,
             iteration_name,
             output_directory=output_file_directory,
-            summary_file="SummaryOfResults_DU.txt",
-            csv_f_1="TimeDependentValues_DU.csv",
-            csv_f_2="BorefieldData_DU.csv",
-            csv_f_3="Loadings_DU.csv",
-            csv_f_4="GFunction_DU.csv",
+            file_suffix="_DU",
             load_method=DesignMethod.Hybrid,
         )
 
@@ -323,7 +315,7 @@ class TestFindNearSquareDesign(GHEBaseTest):
         self.log(f"Number of boreholes: {nbh}")
         self.log(f"Total Drilling: {bisection_search.ghe.bhe.b.H * nbh:0.1f} meters\n")
         # Generating Output File
-        output_design_details(
+        write_output_files(
             bisection_search,
             toc - tic,
             project_name,
@@ -331,10 +323,6 @@ class TestFindNearSquareDesign(GHEBaseTest):
             author,
             iteration_name,
             output_directory=output_file_directory,
-            summary_file="SummaryOfResults_C.txt",
-            csv_f_1="TimeDependentValues_C.csv",
-            csv_f_2="BorefieldData_C.csv",
-            csv_f_3="Loadings_C.csv",
-            csv_f_4="GFunction_C.csv",
+            file_suffix="_C",
             load_method=DesignMethod.Hybrid,
         )

--- a/ghedesigner/tests/test_find_design_near_square_multiyear.py
+++ b/ghedesigner/tests/test_find_design_near_square_multiyear.py
@@ -10,7 +10,7 @@ from ghedesigner.borehole_heat_exchangers import SingleUTube, MultipleUTube, Coa
 from ghedesigner.design import DesignNearSquare
 from ghedesigner.geometry import GeometricConstraints
 from ghedesigner.media import Pipe, Soil, Grout, GHEFluid, SimulationParameters
-from ghedesigner.output import output_design_details
+from ghedesigner.output import write_output_files
 from ghedesigner.tests.ghe_base_case import GHEBaseTest
 from ghedesigner.utilities import DesignMethod, length_of_side
 
@@ -149,7 +149,7 @@ class TestFindNearSquareMultiyearDesign(GHEBaseTest):
         self.log(f"Total Drilling: {bisection_search.ghe.bhe.b.H * nbh:0.1f} meters\n")
 
         # Generating Output File
-        output_design_details(
+        write_output_files(
             bisection_search,
             toc - tic,
             project_name,
@@ -157,11 +157,7 @@ class TestFindNearSquareMultiyearDesign(GHEBaseTest):
             author,
             iteration_name,
             output_directory=output_file_directory,
-            summary_file="SummaryOfResults_SU.txt",
-            csv_f_1="TimeDependentValues_SU.csv",
-            csv_f_2="BorefieldData_SU.csv",
-            csv_f_3="Loadings_SU.csv",
-            csv_f_4="GFunction_SU.csv",
+            file_suffix="_SU",
             load_method=DesignMethod.Hybrid
         )
 
@@ -212,7 +208,7 @@ class TestFindNearSquareMultiyearDesign(GHEBaseTest):
         self.log(f"Total Drilling: {bisection_search.ghe.bhe.b.H * nbh:0.1f} meters\n")
 
         # Generating Output File
-        output_design_details(
+        write_output_files(
             bisection_search,
             toc - tic,
             project_name,
@@ -220,11 +216,8 @@ class TestFindNearSquareMultiyearDesign(GHEBaseTest):
             author,
             iteration_name,
             output_directory=output_file_directory,
-            summary_file="SummaryOfResults_DU.txt",  # TODO: Use unique output file names for each test
-            csv_f_1="TimeDependentValues_DU.csv",
-            csv_f_2="BorefieldData_DU.csv",
-            csv_f_3="Loadings_DU.csv",
-            csv_f_4="GFunction_DU.csv",
+            # TODO: Use unique output file names for each test
+            file_suffix="_DU",
             load_method=DesignMethod.Hybrid,
         )
 
@@ -290,7 +283,7 @@ class TestFindNearSquareMultiyearDesign(GHEBaseTest):
         self.log(f"Total Drilling: {bisection_search.ghe.bhe.b.H * nbh:0.1f} meters\n")
 
         # Generating Output File
-        output_design_details(
+        write_output_files(
             bisection_search,
             toc - tic,
             project_name,
@@ -298,10 +291,6 @@ class TestFindNearSquareMultiyearDesign(GHEBaseTest):
             author,
             iteration_name,
             output_directory=output_file_directory,
-            summary_file="SummaryOfResults_C.txt",
-            csv_f_1="TimeDependentValues_C.csv",
-            csv_f_2="BorefieldData_C.csv",
-            csv_f_3="Loadings_C.csv",
-            csv_f_4="GFunction_C.csv",
+            file_suffix="_C",
             load_method=DesignMethod.Hybrid
         )

--- a/ghedesigner/tests/test_find_design_rowwise.py
+++ b/ghedesigner/tests/test_find_design_rowwise.py
@@ -12,7 +12,7 @@ from ghedesigner.borehole_heat_exchangers import SingleUTube
 from ghedesigner.design import DesignRowWise
 from ghedesigner.geometry import GeometricConstraints
 from ghedesigner.media import Pipe, Soil, Grout, GHEFluid, SimulationParameters
-from ghedesigner.output import output_design_details
+from ghedesigner.output import write_output_files
 from ghedesigner.rowwise import gen_shape
 from ghedesigner.tests.ghe_base_case import GHEBaseTest
 from ghedesigner.utilities import DesignMethod
@@ -194,7 +194,7 @@ class TestFindRowWiseDesign(GHEBaseTest):
         self.log(f"Total Drilling: {bisection_search.ghe.bhe.b.H * nbh:0.1f} meters\n")
 
         # Generating Output File
-        output_design_details(
+        write_output_files(
             bisection_search,
             toc - tic,
             project_name,
@@ -202,11 +202,7 @@ class TestFindRowWiseDesign(GHEBaseTest):
             author,
             iteration_name,
             output_directory=output_file_directory,
-            summary_file="SummaryOfResults_SU_WOP.txt",
-            csv_f_1="TimeDependentValues_SU_WOP.csv",
-            csv_f_2="BorefieldData_SU_WOP.csv",
-            csv_f_3="Loadings_SU_WOP.csv",
-            csv_f_4="GFunction_SU_WOP.csv",
+            file_suffix="_SU_WOP",
             load_method=DesignMethod.Hybrid,
         )
 
@@ -249,7 +245,7 @@ class TestFindRowWiseDesign(GHEBaseTest):
         self.log(f"Total Drilling: {bisection_search.ghe.bhe.b.H * nbh:0.1f} meters\n")
 
         # Generating Output File
-        output_design_details(
+        write_output_files(
             bisection_search,
             toc - tic,
             project_name,
@@ -257,10 +253,6 @@ class TestFindRowWiseDesign(GHEBaseTest):
             author,
             iteration_name,
             output_directory=output_file_directory,
-            summary_file="SummaryOfResults_SU_WP.txt",
-            csv_f_1="TimeDependentValues_SU_WP.csv",
-            csv_f_2="BorefieldData_SU_WP.csv",
-            csv_f_3="Loadings_SU_WP.csv",
-            csv_f_4="GFunction_SU_WP.csv",
+            file_suffix="_SU_WP",
             load_method=DesignMethod.Hybrid,
         )


### PR DESCRIPTION
Pull request overview
--------------
Getting the human readable version back from the JSON was not working, and had to back up anyway to fix a few bugs that are already in the main branch.  With this branch, the summary dict is available through an API call to `get_design_summary_object()`.  By default, when the code runs, it will create both the txt human version as well as the new JSON output file.

Some next steps:
 - Allow switches in the input file, and maybe the CLI, to select which output file(s) to create
 - Move the API demo files to access the summary object and add some assertions to them
 - Use unique file suffixes in all the demos so the files don't overwrite each other as all the tests run

If CI is all clean, this should be able to drop right in.  I'm closing the other PR now.