### PR TITLE
Fix Windows Install Bug Caused by non-utf8 Characters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 from ghedesigner import VERSION
 
 readme_file = Path(__file__).parent.resolve() / 'README.md'
-readme_contents = readme_file.read_text()
+readme_contents = readme_file.read_text(encoding='utf8')
 
 short_description = """A ground heat exchanger design tool with the capability
 to select and size flexibly configured borehole fields that are customized


### PR DESCRIPTION
Pull request overview
--------------
@prsh5175 pointed out that pip installation was failing on his Windows box running Anaconda, which was throwing the following error: 

``UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position``

Googling that lead me to this (https://stackoverflow.com/a/49642852/5965685) post describing Windows encoding problems for the double-quote characters `"`. This PR forces setup.py to load the README as utf-8.

### Checklist
- [ ] Documentation added/updated
- [ ] CI status: all green or justified
