### PR TITLE
Clean up CLI args

### DIFF
--- a/ghedesigner/manager.py
+++ b/ghedesigner/manager.py
@@ -703,6 +703,10 @@ def run_manager_from_cli_worker(input_file_path: Path, output_directory: Path) -
         print(f"No input file found at {input_file_path}, aborting", file=stderr)
         return 1
 
+    if output_directory is None:
+        print("Output directory must be passed as an argument, aborting", file=stderr)
+        return 1
+
     # validate inputs against schema before doing anything
     if validate_input_file(input_file_path) != 0:
         return 1
@@ -883,13 +887,10 @@ def run_manager_from_cli(input_path, output_directory, validate):
             return 1
 
     if output_directory is None:
-        print('Output directory path must be passed as an argument.')
+        print('Output directory path must be passed as an argument, aborting', file=stderr)
         return 1
 
     output_path = Path(output_directory).resolve()
-
-    if not input_path.exists():
-        print(f'Input file does not exist. Input file path: "{str(input_path)}"', file=stderr)
 
     return run_manager_from_cli_worker(input_path, output_path)
 

--- a/ghedesigner/manager.py
+++ b/ghedesigner/manager.py
@@ -861,7 +861,7 @@ def run_manager_from_cli_worker(input_file_path: Path, output_directory: Path) -
 
 @click.command(name="GHEDesignerCommandLine")
 @click.argument("input-path", type=click.Path(exists=True), required=True)
-@click.argument("output-directory", required=True)
+@click.argument("output-directory", required=False)
 @click.version_option(VERSION)
 @click.option(
     "--validate",
@@ -881,6 +881,10 @@ def run_manager_from_cli(input_path, output_directory, validate):
         except ValidationError:
             print("Schema validation error. See previous error message for details.", file=stderr)
             return 1
+
+    if output_directory is None:
+        print('Output directory path must be passed as an argument.')
+        return 1
 
     output_path = Path(output_directory).resolve()
 

--- a/ghedesigner/manager.py
+++ b/ghedesigner/manager.py
@@ -860,8 +860,8 @@ def run_manager_from_cli_worker(input_file_path: Path, output_directory: Path) -
 
 
 @click.command(name="GHEDesignerCommandLine")
-@click.argument("input-path", type=click.Path(exists=True))
-@click.argument("output-directory", type=click.Path(exists=True), required=False)
+@click.argument("input-path", type=click.Path(exists=True), required=True)
+@click.argument("output-directory", required=True)
 @click.version_option(VERSION)
 @click.option(
     "--validate",

--- a/ghedesigner/manager.py
+++ b/ghedesigner/manager.py
@@ -861,7 +861,7 @@ def run_manager_from_cli_worker(input_file_path: Path, output_directory: Path) -
 
 @click.command(name="GHEDesignerCommandLine")
 @click.argument("input-path", type=click.Path(exists=True), required=True)
-@click.argument("output-directory", required=False)
+@click.argument("output-directory", type=click.Path(exists=False), required=False)
 @click.version_option(VERSION)
 @click.option(
     "--validate",


### PR DESCRIPTION
Pull request overview
---------------------
The CLI args were a bit haphazard. This cleans it up.
- The output directory CLI arg required the directory to exist, but then there were checks later in the code that would check if it exists, and create it if needed. This removes the requirement for the directory to exist because we can create it on the fly, and also makes the argument required so we don't have to guess where to put the files.
- The input file CLI arg required the file to exist but then it also wasn't a required argument. This makes the argument required explicitly.

### Checklist
- [ ] Documentation added/updated
- [ ] CI status: all green or justified
