### PR TITLE
Use compatible-release dependency specification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # library dependencies
-click>=8.1.7
-jsonschema>=4.19.1
-numpy>=1.24.2
-pygfunction>=2.2.2
-scipy>=1.10.1
+click~=8.1
+jsonschema~=4.19
+numpy~=1.24
+pygfunction~=2.2
+scipy~=1.10
 
 # docs dependencies
 sphinx>=7.1.2

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,11 @@ for specific building and property constraints."""
 setup(
     name='GHEDesigner',
     install_requires=[
-        'click>=8.1.7',
-        'jsonschema>=4.19.1',
-        'numpy>=1.24.2',
-        'pygfunction>=2.2.2',
-        'scipy>=1.10.1'
+        'click~=8.1',
+        'jsonschema~=4.19',
+        'numpy~=1.24',
+        'pygfunction~=2.2',
+        'scipy~=1.10'
     ],
     url='https://github.com/BETSRG/GHEDesigner',
     description=short_description,


### PR DESCRIPTION
Pull request overview
---------------------
Use [compatible release](https://packaging.python.org/en/latest/specifications/version-specifiers/#compatible-release) for specifying dependencies, to improve compatibility between packages that interact with GHED.

- PR is part of the resolution for https://github.com/urbanopt/urbanopt-cli/issues/459

### Checklist
- [ ] ~Documentation added/updated~
- [x] CI status: all green or justified
