### PR TITLE
Schema fixes

### DIFF
--- a/ghedesigner/schemas/ghedesigner.schema.json
+++ b/ghedesigner/schemas/ghedesigner.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
     "topology": {
@@ -206,9 +206,12 @@
                 "description": "Outer pipe outer diameter."
               }
             },
-            "dependentRequired": {
-              "arrangement": {
-                "SINGLEUTUBE": [
+            "oneOf": [
+              {
+                "properties": {
+                  "arrangement": { "const": "SINGLEUTUBE" }
+                },
+                "required": [
                   "inner_diameter",
                   "outer_diameter",
                   "shank_spacing",
@@ -216,8 +219,13 @@
                   "conductivity",
                   "rho_cp",
                   "arrangement"
-                ],
-                "DOUBLEUTUBESERIES": [
+                ]
+              },
+              {
+                "properties": {
+                  "arrangement": { "const": "DOUBLEUTUBESERIES" }
+                },
+                "required": [
                   "inner_diameter",
                   "outer_diameter",
                   "shank_spacing",
@@ -225,8 +233,13 @@
                   "conductivity",
                   "rho_cp",
                   "arrangement"
-                ],
-                "DOUBLEUTUBEPARALLEL": [
+                ]
+              },
+              {
+                "properties": {
+                  "arrangement": { "const": "DOUBLEUTUBEPARALLEL" }
+                },
+                "required": [
                   "inner_diameter",
                   "outer_diameter",
                   "shank_spacing",
@@ -234,8 +247,13 @@
                   "conductivity",
                   "rho_cp",
                   "arrangement"
-                ],
-                "COAXIAL": [
+                ]
+              },
+              {
+                "properties": {
+                  "arrangement": { "const": "COAXIAL" }
+                },
+                "required": [
                   "inner_pipe_d_in",
                   "inner_pipe_d_out",
                   "outer_pipe_d_in",
@@ -247,7 +265,7 @@
                   "arrangement"
                 ]
               }
-            }
+            ]
           },
           "borehole": {
             "type": "object",
@@ -313,7 +331,14 @@
               },
               "method": {
                 "type": "string",
-                "const": "BIRECTANGLE",
+                "enum": [
+                  "BIRECTANGLE",
+                  "BIRECTANGLECONSTRAINED",
+                  "BIZONEDRECTANGLE",
+                  "NEARSQUARE",
+                  "RECTANGLE",
+                  "ROWWISE"
+                ],
                 "description": "Design algorithm specified."
               },
               "property_boundary": {
@@ -403,37 +428,61 @@
                 "description": "Step size for field rotation search."
               }
             },
-            "dependentRequired": {
-              "method": {
-                "BIRECTANGLE": [
+            "oneOf": [
+              {
+                "properties": { "method": { "const": "BIRECTANGLE" } },
+                "required": [
                   "length",
                   "width",
                   "b_min",
                   "b_max_x",
                   "b_max_y",
                   "max_height",
-                  "min_height"
-                ],
-                "BIRECTANGLECONSTRAINED": [
+                  "min_height",
+                  "method"
+                ]
+              },
+              {
+                "properties": {
+                  "method": { "const": "BIRECTANGLECONSTRAINED" }
+                },
+                "required": [
                   "b_min",
                   "b_max_x",
                   "b_max_y",
                   "max_height",
                   "min_height",
                   "property_boundary",
-                  "no_go_boundaries"
-                ],
-                "BIZONEDRECTANGLE": [
+                  "no_go_boundaries",
+                  "method"
+                ]
+              },
+              {
+                "properties": { "method": { "const": "BIZONEDRECTANGLE" } },
+                "required": [
                   "length",
                   "width",
                   "b_min",
                   "b_max_x",
                   "b_max_y",
                   "max_height",
-                  "min_height"
-                ],
-                "NEARSQUARE": ["length", "b", "max_height", "min_height"],
-                "RECTANGLE": [
+                  "min_height",
+                  "method"
+                ]
+              },
+              {
+                "properties": { "method": { "const": "NEARSQUARE" } },
+                "required": [
+                  "length",
+                  "b",
+                  "max_height",
+                  "min_height",
+                  "method"
+                ]
+              },
+              {
+                "properties": { "method": { "const": "RECTANGLE" } },
+                "required": [
                   "length",
                   "width",
                   "b_min",
@@ -441,8 +490,11 @@
                   "max_height",
                   "min_height",
                   "method"
-                ],
-                "ROWWISE": [
+                ]
+              },
+              {
+                "properties": { "method": { "const": "ROWWISE" } },
+                "required": [
                   "perimeter_spacing_ratio",
                   "min_spacing",
                   "max_spacing",
@@ -457,7 +509,7 @@
                   "method"
                 ]
               }
-            }
+            ]
           },
           "design": {
             "type": "object",

--- a/poetry.lock
+++ b/poetry.lock
@@ -1038,9 +1038,9 @@ testing = ["matplotlib (>=3.8.4)", "pytest (>=7.1.1)", "pytest-cov (>=3.0.0)", "
 
 [package.source]
 type = "git"
-url = "https://github.com/axelstudios/pygfunction.git"
-reference = "task/refactor-matplotlib"
-resolved_reference = "3555f729e57c42d623af37051637c531466651e7"
+url = "https://github.com/MassimoCimmino/pygfunction.git"
+reference = "7b26877cb2224bf53c70b9ff8de362b4bd977616"
+resolved_reference = "7b26877cb2224bf53c70b9ff8de362b4bd977616"
 
 [[package]]
 name = "pygments"
@@ -1682,4 +1682,4 @@ viz = ["cartopy", "matplotlib", "nc-time-axis", "seaborn"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.14"
-content-hash = "236fdb4eb5769ff644e7ba7465bba57929fecb1a24b9e2ff2fd3d32c465fc525"
+content-hash = "57514c74a6df2dceb216dbac10bd7957fae36e0124385b6886c65aa1f0a2e209"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ python = ">=3.10, <3.14"
 click = "^8.1"
 jsonschema = "^4.19"
 numpy = "^2.0.0"
-pygfunction = { git = "https://github.com/axelstudios/pygfunction.git", branch = "task/refactor-matplotlib" }
+pygfunction = { git = "https://github.com/MassimoCimmino/pygfunction.git", rev = "7b26877cb2224bf53c70b9ff8de362b4bd977616" }
 scipy = "^1.14"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Pull request overview

The GHEDesigner schema referenced `draft-04` version compatibility, but was using `2019‑09` features (`dependentRequired`).

This PR fixes schema errors, and makes the schema fully compatible with `draft-04 / 06 / 07 / 2019-09 / 2020-12`, while specifying `draft-07` as the version for legacy and tooling considerations.

It also updates the pygfunction sha reference.