### PR TITLE
Remove tests from build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
 ]
+exclude = ["**/tests"]
 
 [tool.poetry.dependencies]
 python = ">=3.10, <3.14"


### PR DESCRIPTION
## Pull request overview

This PR excludes `tests` directories from being packaged into the build wheel, resulting in a 72% filesize reduction:

`322 KiB` ➡️ `89 KiB`