### PR TITLE
Fix demo_outputs directories

### DIFF
--- a/.spelling.dic
+++ b/.spelling.dic
@@ -54,6 +54,7 @@ spitler
 ubwt
 uhtr
 vdot
+workerinput
 xiaobing
 xlabel
 ylabel

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+
+def is_controller(config):
+    # controller has no workerinput attribute
+    return not hasattr(config, "workerinput")
+
+
+def pytest_configure(config):
+    # only runs once, on the controller process
+    if is_controller(config):
+        config.time_str = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+def pytest_configure_node(node):
+    # xdist hook: before a worker starts, copy the controller's timestamp in
+    node.workerinput["time_str"] = node.config.time_str
+
+
+def pytest_generate_tests(metafunc):
+    # for any test that asks for a `time_str` argument,
+    # inject exactly one parameter (the same timestamp in all workers)
+    if "time_str" in metafunc.fixturenames:
+        timestamp = (
+            metafunc.config.time_str if is_controller(metafunc.config) else metafunc.config.workerinput["time_str"]
+        )
+        metafunc.parametrize("time_str", [timestamp], scope="session")

--- a/ghedesigner/tests/test_demo_files.py
+++ b/ghedesigner/tests/test_demo_files.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from json import loads
 from pathlib import Path
 
@@ -41,8 +40,7 @@ def get_test_input_files() -> list[Path]:
 
 
 @pytest.mark.parametrize("demo_file_path", get_test_input_files(), ids=lambda f: "Demo: " + f.stem)
-def test_demo_files(demo_file_path: Path):
-    time_str = datetime.now().strftime("%Y%m%d_%H%M%S")
+def test_demo_files(demo_file_path: Path, time_str: str):
     failed_tests = []
 
     # run demo files first


### PR DESCRIPTION
## Pull request overview

After switching to running the tests in parallel, it inadvertently resulted in multiple `demo_outputs/{timestamp}` directories being created with each run of pytest, since each worker generated a different timestamp.

This PR adds a `conftest.py` file to create the timestamp in the controller node, and to pass it to tests in workers that request it.