### PR TITLE
Move click-decoarated function from return-ing to exit-ing

### DIFF
--- a/ghedesigner/main.py
+++ b/ghedesigner/main.py
@@ -5,7 +5,7 @@ from json import loads
 from pathlib import Path
 
 import click
-from jsonschema import ValidationError
+from jsonschema.exceptions import ValidationError
 
 from ghedesigner.constants import VERSION
 from ghedesigner.enums import TimestepType
@@ -126,39 +126,44 @@ def run(input_file_path: Path, output_directory: Path) -> int:
 @click.option("--validate-only", default=False, is_flag=True, show_default=False, help="Validate input file and exit.")
 @click.option("-c", "--convert", help="Convert output to specified format. Options supported: 'IDF'.")
 def run_manager_from_cli(input_path, output_directory, validate_only, convert):
+    # Note that since this is wrapped in click, it should use the exit(code) instead of return.
+    # Click will absorb the return code and not return it.
+    # If we use exit(code), it will return the code properly.
     input_path = Path(input_path).resolve()
 
     if validate_only:
         try:
             validate_input_file(input_path)
             logger.info("Valid input file.")
-            return 0
+            sys.exit(0)
         except ValidationError as ve:
             logger.error(ve)
-            return 1
+            sys.exit(1)
 
     if convert:
         if convert == "IDF":
             try:
                 write_idf(input_path)
                 print("Output converted to IDF objects.")
-                return 0
+                sys.exit(0)
             except Exception as e:  # noqa: BLE001
                 logger.warning(f"Conversion to IDF error: {e}")
-                return 1
+                sys.exit(1)
 
         else:
             print(f"Unsupported conversion format type: {format}", file=sys.stderr)
-            return 1
+            sys.exit(1)
 
     if output_directory is None:
         print("Output directory path must be passed as an argument, aborting", file=sys.stderr)
-        return 1
+        sys.exit(1)
 
     output_path = Path(output_directory).resolve()
 
-    return run(input_path, output_path)
+    return_code = run(input_path, output_path)
+    sys.exit(return_code)
 
 
 if __name__ == "__main__":
-    sys.exit(run_manager_from_cli())
+    exit_code = run_manager_from_cli()
+    sys.exit(exit_code)

--- a/ghedesigner/validate.py
+++ b/ghedesigner/validate.py
@@ -3,7 +3,8 @@ import sys
 from json import loads
 from pathlib import Path
 
-from jsonschema import ValidationError, validate
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
 
 # Note: JSON schema does not currently have a good way to handle case-insensitive enums.
 #       I think we should enforce case sensitivity.  The validation script should clearly alert the user.
@@ -32,7 +33,7 @@ def validate_input_file(input_file_path: Path) -> None:
         elif "type" in error.schema:
             print(f"{fix}  Ensure the value is of type: {error.schema['type']}")
         print("For example inputs, see the demo files.", file=sys.stderr)
-        raise ValidationError("") from None
+        raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Pull request overview

- The click-decorated entry point does not respect normal return values.  (https://github.com/pallets/click/issues/747#issuecomment-285865759).  This just changes the return to an exit, which click then handles and ends up returning that to the shell.  
- I also just changed a couple imports to get the ValidationError from the exceptions nested package, no functional change.
- I also just did a `raise` instead of constructing a second ValidationError in the validate function.

### Checklist

- [ ] Documentation added/updated
- [ ] CI status: all green or justified
