### PR TITLE
Use Local `SecondaryCoolantProps`

### DIFF
--- a/ghedesigner/ghe/boreholes/base.py
+++ b/ghedesigner/ghe/boreholes/base.py
@@ -4,14 +4,14 @@ from pygfunction.boreholes import Borehole
 
 from ghedesigner.constants import PI, TWO_PI
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 
 
 class GHEDesignerBoreholeBase:
     def __init__(
         self,
         m_flow_borehole: float,
-        fluid: GHEFluid,
+        fluid: Fluid,
         borehole: Borehole,
         pipe: Pipe,
         grout: Grout,
@@ -33,7 +33,7 @@ class GHEDesignerBoreholeBase:
         return 1 / (h_conv * TWO_PI * radius)
 
     @staticmethod
-    def compute_reynolds(m_flow_pipe: float, r_in: float, fluid: GHEFluid) -> float:
+    def compute_reynolds(m_flow_pipe: float, r_in: float, fluid: Fluid) -> float:
         # Hydraulic diameter
         dia_hydraulic = 2.0 * r_in
         # Fluid velocity

--- a/ghedesigner/ghe/boreholes/coaxial_borehole.py
+++ b/ghedesigner/ghe/boreholes/coaxial_borehole.py
@@ -7,12 +7,12 @@ from ghedesigner.constants import PI
 from ghedesigner.ghe.boreholes.multi_u_borehole import GHEDesignerBoreholeWithMultiplePipes
 from ghedesigner.ghe.boreholes.single_u_borehole import SingleUTube
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 
 
 class CoaxialPipe(GHEDesignerBoreholeWithMultiplePipes):
     def __init__(
-        self, m_flow_borehole: float, fluid: GHEFluid, borehole: Borehole, pipe: Pipe, grout: Grout, soil: Soil
+        self, m_flow_borehole: float, fluid: Fluid, borehole: Borehole, pipe: Pipe, grout: Grout, soil: Soil
     ) -> None:
         super().__init__(m_flow_borehole, fluid, borehole, pipe, grout, soil)
 
@@ -68,7 +68,7 @@ class CoaxialPipe(GHEDesignerBoreholeWithMultiplePipes):
         return new_single_u_tube
 
     @staticmethod
-    def compute_reynolds_concentric(m_flow_pipe: float, r_a_in: float, r_a_out: float, fluid: GHEFluid) -> float:
+    def compute_reynolds_concentric(m_flow_pipe: float, r_a_in: float, r_a_out: float, fluid: Fluid) -> float:
         # Hydraulic diameter and radius for concentric tube annulus region
         dia_hydraulic = 2 * (r_a_out - r_a_in)
         # r_h = dia_hydraulic / 2

--- a/ghedesigner/ghe/boreholes/coaxial_borehole.py
+++ b/ghedesigner/ghe/boreholes/coaxial_borehole.py
@@ -59,7 +59,7 @@ class CoaxialPipe(GHEDesignerBoreholeWithMultiplePipes):
 
         resist_conv = self.bhr_borehole.calc_fluid_resist(self.m_flow_borehole, self.soil.ugt)
         resist_pipe = self.bhr_borehole.calc_pipe_cond_resist()
-        preliminary = self.equivalent_single_u_tube(vol_fluid, vol_pipe, resist_conv, resist_pipe, self.pipe.rhoCp)
+        preliminary = self.equivalent_single_u_tube(vol_fluid, vol_pipe, resist_conv, resist_pipe, self.pipe.rho_cp)
 
         # Vary grout thermal conductivity to match effective borehole thermal
         # resistance

--- a/ghedesigner/ghe/boreholes/factory.py
+++ b/ghedesigner/ghe/boreholes/factory.py
@@ -5,13 +5,13 @@ from ghedesigner.ghe.boreholes.coaxial_borehole import CoaxialPipe
 from ghedesigner.ghe.boreholes.multi_u_borehole import MultipleUTube
 from ghedesigner.ghe.boreholes.single_u_borehole import SingleUTube
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 
 
 def get_bhe_object(
     bhe_type: PipeType,
     m_flow_borehole: float,
-    fluid: GHEFluid,
+    fluid: Fluid,
     borehole: Borehole,
     pipe: Pipe,
     grout: Grout,

--- a/ghedesigner/ghe/boreholes/multi_u_borehole.py
+++ b/ghedesigner/ghe/boreholes/multi_u_borehole.py
@@ -56,7 +56,7 @@ class GHEDesignerBoreholeWithMultiplePipes(GHEDesignerBoreholeBase):
         m_flow_borehole = self.m_flow_borehole
         fluid = self.fluid
 
-        grout = Grout(self.grout.k, self.grout.rhoCp)
+        grout = Grout(self.grout.k, self.grout.rho_cp)
         soil = self.soil
 
         # Maintain the same mass flow rate so that the Rb/Rb* is not diverged from
@@ -183,7 +183,7 @@ class MultipleUTube(GHEDesignerBoreholeWithMultiplePipes):
         resist_pipe = self.bhr_borehole.calc_pipe_cond_resist()
         resist_conv = self.R_fp - resist_pipe
 
-        single_u_tube = self.equivalent_single_u_tube(vol_fluid, vol_pipe, resist_conv, resist_pipe, self.pipe.rhoCp)
+        single_u_tube = self.equivalent_single_u_tube(vol_fluid, vol_pipe, resist_conv, resist_pipe, self.pipe.rho_cp)
 
         # Vary grout thermal conductivity to match effective borehole thermal resistance
         self.match_effective_borehole_resistance(single_u_tube)

--- a/ghedesigner/ghe/boreholes/multi_u_borehole.py
+++ b/ghedesigner/ghe/boreholes/multi_u_borehole.py
@@ -10,7 +10,7 @@ from ghedesigner.enums import DoubleUTubeConnType
 from ghedesigner.ghe.boreholes.base import GHEDesignerBoreholeBase
 from ghedesigner.ghe.boreholes.single_u_borehole import SingleUTube
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.utilities import solve_root
 
 
@@ -112,7 +112,7 @@ class MultipleUTube(GHEDesignerBoreholeWithMultiplePipes):
     def __init__(
         self,
         m_flow_borehole: float,
-        fluid: GHEFluid,
+        fluid: Fluid,
         borehole: Borehole,
         pipe: Pipe,
         grout: Grout,

--- a/ghedesigner/ghe/boreholes/single_u_borehole.py
+++ b/ghedesigner/ghe/boreholes/single_u_borehole.py
@@ -156,7 +156,7 @@ class SingleUTube(GHEDesignerBoreholeBase):
         # The equivalent thermal mass of the fluid can be calculated from
         # equation (2)
         # pi (r_in_conv ** 2 - r_f **2) C_eq_f = 2pi r_p_in**2 * C_f
-        rho_cp_eq_fluid = 2.0 * (self.pipe.r_in**2) * self.fluid.rhoCp
+        rho_cp_eq_fluid = 2.0 * (self.pipe.r_in**2) * self.fluid.rho_cp
         rho_cp_eq_fluid /= (self.r_convection**2) - (self.r_fluid**2)
         conductivity_fluid = 200
         for idx in range(cell_summation, self.num_fluid_cells + cell_summation):
@@ -180,7 +180,7 @@ class SingleUTube(GHEDesignerBoreholeBase):
 
         # load pipe cells
         conductivity_pipe_grout = log(self.r_borehole / self.r_in_tube) / (TWO_PI * resist_pg_effective)
-        rho_cp_pipe = self.pipe.rhoCp
+        rho_cp_pipe = self.pipe.rho_cp
         for j, idx in enumerate(range(cell_summation, self.num_pipe_cells + cell_summation)):
             inner_radius_pipe_cell = self.r_in_tube + j * self.thickness_pipe_cell
             radial_cells[:, idx] = fill_single_cell(
@@ -190,7 +190,7 @@ class SingleUTube(GHEDesignerBoreholeBase):
         cell_summation += self.num_pipe_cells
 
         # load grout cells
-        rho_cp_grout = self.grout.rhoCp
+        rho_cp_grout = self.grout.rho_cp
         for j, idx in enumerate(range(cell_summation, self.num_grout_cells + cell_summation)):
             inner_radius_grout_cell = self.r_out_tube + j * self.thickness_grout_cell
             radial_cells[:, idx] = fill_single_cell(
@@ -201,7 +201,7 @@ class SingleUTube(GHEDesignerBoreholeBase):
 
         # load soil cells
         conductivity_soil = self.soil.k
-        rho_cp_soil = self.soil.rhoCp
+        rho_cp_soil = self.soil.rho_cp
         for j, idx in enumerate(range(cell_summation, self.num_soil_cells + cell_summation)):
             inner_radius_soil_cell = self.r_borehole + j * self.thickness_soil_cell
             radial_cells[:, idx] = fill_single_cell(

--- a/ghedesigner/ghe/boreholes/single_u_borehole.py
+++ b/ghedesigner/ghe/boreholes/single_u_borehole.py
@@ -11,7 +11,7 @@ from scipy.linalg.lapack import dgtsv
 from ghedesigner.constants import SEC_IN_HR, TWO_PI
 from ghedesigner.ghe.boreholes.base import GHEDesignerBoreholeBase
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 
 
 class CellProps(IntEnum):
@@ -28,7 +28,7 @@ class SingleUTube(GHEDesignerBoreholeBase):
     def __init__(
         self,
         m_flow_borehole: float,
-        fluid: GHEFluid,
+        fluid: Fluid,
         borehole: Borehole,
         pipe: Pipe,
         grout: Grout,

--- a/ghedesigner/ghe/design/base.py
+++ b/ghedesigner/ghe/design/base.py
@@ -9,7 +9,7 @@ from ghedesigner.ghe.search.bisection_1d import Bisection1D
 from ghedesigner.ghe.search.bisection_2d import Bisection2D
 from ghedesigner.ghe.search.bisection_zd import BisectionZD
 from ghedesigner.ghe.search.rowwise import RowWiseModifiedBisectionSearch
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 
 AnyBisectionType = Bisection1D | Bisection2D | BisectionZD | RowWiseModifiedBisectionSearch
 
@@ -29,7 +29,7 @@ class DesignBase:
         self,
         v_flow: float,
         borehole: Borehole,
-        fluid: GHEFluid,
+        fluid: Fluid,
         pipe: Pipe,
         grout: Grout,
         soil: Soil,

--- a/ghedesigner/ghe/design/birectangle.py
+++ b/ghedesigner/ghe/design/birectangle.py
@@ -7,7 +7,7 @@ from ghedesigner.ghe.design.base import DesignBase, GeometricConstraints
 from ghedesigner.ghe.domains import bi_rectangle_nested
 from ghedesigner.ghe.pipe import Pipe
 from ghedesigner.ghe.search.bisection_2d import Bisection2D
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 
 
 @dataclass
@@ -35,7 +35,7 @@ class DesignBiRectangle(DesignBase):
         self,
         v_flow: float,
         borehole: Borehole,
-        fluid: GHEFluid,
+        fluid: Fluid,
         pipe: Pipe,
         grout: Grout,
         soil: Soil,

--- a/ghedesigner/ghe/design/birectangle_constrained.py
+++ b/ghedesigner/ghe/design/birectangle_constrained.py
@@ -8,7 +8,7 @@ from ghedesigner.ghe.design.base import DesignBase, GeometricConstraints
 from ghedesigner.ghe.domains import polygonal_land_constraint
 from ghedesigner.ghe.pipe import Pipe
 from ghedesigner.ghe.search.bisection_zd import BisectionZD
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 
 
 def is_2d(property_boundary: list[list[float]] | list[list[list[float]]]) -> TypeGuard[list[list[float]]]:
@@ -58,7 +58,7 @@ class DesignBiRectangleConstrained(DesignBase):
         self,
         v_flow: float,
         borehole: Borehole,
-        fluid: GHEFluid,
+        fluid: Fluid,
         pipe: Pipe,
         grout: Grout,
         soil: Soil,

--- a/ghedesigner/ghe/design/bizoned.py
+++ b/ghedesigner/ghe/design/bizoned.py
@@ -8,7 +8,7 @@ from ghedesigner.ghe.design.birectangle import GeometricConstraintsBiRectangle
 from ghedesigner.ghe.domains import bi_rectangle_zoned_nested
 from ghedesigner.ghe.pipe import Pipe
 from ghedesigner.ghe.search.bisection_zd import BisectionZD
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 
 
 @dataclass
@@ -36,7 +36,7 @@ class DesignBiZoned(DesignBase):
         self,
         v_flow: float,
         borehole: Borehole,
-        fluid: GHEFluid,
+        fluid: Fluid,
         pipe: Pipe,
         grout: Grout,
         soil: Soil,

--- a/ghedesigner/ghe/design/near_square.py
+++ b/ghedesigner/ghe/design/near_square.py
@@ -8,7 +8,7 @@ from ghedesigner.ghe.design.base import DesignBase, GeometricConstraints
 from ghedesigner.ghe.domains import square_and_near_square
 from ghedesigner.ghe.pipe import Pipe
 from ghedesigner.ghe.search.bisection_1d import Bisection1D
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 
 
 @dataclass
@@ -33,7 +33,7 @@ class DesignNearSquare(DesignBase):
         self,
         v_flow: float,
         borehole: Borehole,
-        fluid: GHEFluid,
+        fluid: Fluid,
         pipe: Pipe,
         grout: Grout,
         soil: Soil,

--- a/ghedesigner/ghe/design/rectangle.py
+++ b/ghedesigner/ghe/design/rectangle.py
@@ -7,7 +7,7 @@ from ghedesigner.ghe.design.base import DesignBase, GeometricConstraints
 from ghedesigner.ghe.domains import rectangular
 from ghedesigner.ghe.pipe import Pipe
 from ghedesigner.ghe.search.bisection_1d import Bisection1D
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 
 
 @dataclass
@@ -34,7 +34,7 @@ class DesignRectangle(DesignBase):
         self,
         v_flow: float,
         borehole: Borehole,
-        fluid: GHEFluid,
+        fluid: Fluid,
         pipe: Pipe,
         grout: Grout,
         soil: Soil,

--- a/ghedesigner/ghe/design/rowwise.py
+++ b/ghedesigner/ghe/design/rowwise.py
@@ -7,7 +7,7 @@ from ghedesigner.enums import DesignGeomType, FlowConfigType, TimestepType
 from ghedesigner.ghe.design.base import DesignBase, GeometricConstraints
 from ghedesigner.ghe.pipe import Pipe
 from ghedesigner.ghe.search.rowwise import RowWiseModifiedBisectionSearch
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 
 
 @dataclass
@@ -41,7 +41,7 @@ class DesignRowWise(DesignBase):
         self,
         v_flow: float,
         borehole: Borehole,
-        fluid: GHEFluid,
+        fluid: Fluid,
         pipe: Pipe,
         grout: Grout,
         soil: Soil,

--- a/ghedesigner/ghe/gfunction.py
+++ b/ghedesigner/ghe/gfunction.py
@@ -107,7 +107,7 @@ def calc_g_func_for_multiple_lengths(
     r_b_values = dict.fromkeys(h_values, r_b)
     g_lts_values = {}
 
-    alpha = soil.k / soil.rhoCp
+    alpha = soil.k / soil.rho_cp
 
     for h in h_values:
         borehole = Borehole(h, depth, r_b, 0.0, 0.0)

--- a/ghedesigner/ghe/manager.py
+++ b/ghedesigner/ghe/manager.py
@@ -22,7 +22,7 @@ from ghedesigner.ghe.design.rowwise import DesignRowWise, GeometricConstraintsRo
 from ghedesigner.ghe.gfunction import calculate_g_function
 from ghedesigner.ghe.ground_heat_exchangers import GHE
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.utilities import combine_sts_lts, eskilson_log_times, get_loads
 
 
@@ -42,7 +42,7 @@ class GroundHeatExchanger:  # TODO: Rename this.  Just GHEDesignerManager?  GHED
         fluid_concentration_percent: float = 0.0,
         fluid_temperature: float = 20.0,
     ) -> None:
-        self.fluid = GHEFluid(fluid_name, fluid_concentration_percent, fluid_temperature)
+        self.fluid = Fluid(fluid_name, fluid_temperature, fluid_concentration_percent)
         self.grout = Grout(grout_conductivity, grout_rho_cp)
         self.soil = Soil(soil_conductivity, soil_rho_cp, soil_undisturbed_temperature)
         if pipe_arrangement_type == PipeType.SINGLEUTUBE:

--- a/ghedesigner/ghe/search/bisection_1d.py
+++ b/ghedesigner/ghe/search/bisection_1d.py
@@ -7,7 +7,7 @@ from ghedesigner.enums import FlowConfigType, TimestepType
 from ghedesigner.ghe.gfunction import calc_g_func_for_multiple_lengths
 from ghedesigner.ghe.ground_heat_exchangers import GHE
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.utilities import borehole_spacing, check_bracket, eskilson_log_times, sign
 
 
@@ -18,7 +18,7 @@ class Bisection1D:
         field_descriptors: list,
         v_flow: float,
         borehole: Borehole,
-        fluid: GHEFluid,
+        fluid: Fluid,
         pipe: Pipe,
         grout: Grout,
         soil: Soil,

--- a/ghedesigner/ghe/search/bisection_2d.py
+++ b/ghedesigner/ghe/search/bisection_2d.py
@@ -3,7 +3,7 @@ from pygfunction.boreholes import Borehole
 from ghedesigner.enums import FlowConfigType, TimestepType
 from ghedesigner.ghe.pipe import Pipe
 from ghedesigner.ghe.search.bisection_1d import Bisection1D
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 
 
 class Bisection2D(Bisection1D):
@@ -13,7 +13,7 @@ class Bisection2D(Bisection1D):
         field_descriptors: list,
         v_flow: float,
         borehole: Borehole,
-        fluid: GHEFluid,
+        fluid: Fluid,
         pipe: Pipe,
         grout: Grout,
         soil: Soil,

--- a/ghedesigner/ghe/search/bisection_zd.py
+++ b/ghedesigner/ghe/search/bisection_zd.py
@@ -4,7 +4,7 @@ from pygfunction.boreholes import Borehole
 from ghedesigner.enums import FlowConfigType, TimestepType
 from ghedesigner.ghe.pipe import Pipe
 from ghedesigner.ghe.search.bisection_1d import Bisection1D
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 
 
 class BisectionZD(Bisection1D):
@@ -14,7 +14,7 @@ class BisectionZD(Bisection1D):
         field_descriptors: list,
         v_flow: float,
         borehole: Borehole,
-        fluid: GHEFluid,
+        fluid: Fluid,
         pipe: Pipe,
         grout: Grout,
         soil: Soil,

--- a/ghedesigner/ghe/search/rowwise.py
+++ b/ghedesigner/ghe/search/rowwise.py
@@ -8,7 +8,7 @@ from ghedesigner.ghe.gfunction import calc_g_func_for_multiple_lengths
 from ghedesigner.ghe.ground_heat_exchangers import GHE
 from ghedesigner.ghe.pipe import Pipe
 from ghedesigner.ghe.rowwise import field_optimization_fr, field_optimization_wp_space_fr, gen_shape
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.utilities import borehole_spacing, eskilson_log_times
 
 
@@ -18,7 +18,7 @@ class RowWiseModifiedBisectionSearch:
         self,
         v_flow: float,
         borehole: Borehole,
-        fluid: GHEFluid,
+        fluid: Fluid,
         pipe: Pipe,
         grout: Grout,
         soil: Soil,

--- a/ghedesigner/media.py
+++ b/ghedesigner/media.py
@@ -59,53 +59,29 @@ class Fluid:
         return self._fluid.k(self.temperature)
 
     @property
-    def rhoCp(self) -> float:
+    def rho_cp(self) -> float:
         return self.rho * self.cp
 
     @property
     def alpha(self) -> float:
-        return self.k / self.rhoCp
-
-    # def __post_init__(self, fluid_str: str, percent: float) -> None:
-    #     fluid_type_map = {
-    #         FluidType.ETHYLALCOHOL.name: (FluidType.ETHYLALCOHOL, "MEA"),
-    #         FluidType.ETHYLENEGLYCOL.name: (FluidType.ETHYLENEGLYCOL, "MEG"),
-    #         FluidType.METHYLALCOHOL.name: (FluidType.METHYLALCOHOL, "MMA"),
-    #         FluidType.PROPYLENEGLYCOL.name: (FluidType.PROPYLENEGLYCOL, "MPG"),
-    #         FluidType.WATER.name: (FluidType.WATER, "WATER"),
-    #     }
-    #
-    #     self.concentration_percent = percent
-    #
-    #     try:
-    #         self.fluid_type, fluid_shorthand = fluid_type_map[fluid_str.upper()]
-    #     except KeyError:
-    #         raise ValueError(f'FluidType "{fluid_str}" not implemented')
-    #
-    #     super().__init__(fluid_shorthand, percent, self.temperature)
-    #
-    # def to_input(self) -> dict:
-    #     return {
-    #         **asdict(self, dict_factory=lambda d: {k: v for k, v in d if k not in {"fluid_type"}}),
-    #         "fluid_name": self.fluid_type.name,
-    #     }
+        return self.k / self.rho_cp
 
 
 class ThermalProperty:
     def __init__(self, k, rho_cp: float) -> None:
         self.k = k  # Thermal conductivity (W/m.K)
-        self.rhoCp = rho_cp  # Volumetric heat capacity (J/K.m3)
+        self.rho_cp = rho_cp  # Volumetric heat capacity (J/K.m3)
 
     def as_dict(self) -> dict:
         output = {
             "type": str(self.__class__),
             "thermal_conductivity": {"value": self.k, "units": "W/m-K"},
-            "volumetric_heat_capacity": {"value": self.rhoCp, "units": "J/K-m3"},
+            "volumetric_heat_capacity": {"value": self.rho_cp, "units": "J/K-m3"},
         }
         return output
 
     def to_input(self) -> dict:
-        return {"conductivity": self.k, "rho_cp": self.rhoCp}
+        return {"conductivity": self.k, "rho_cp": self.rho_cp}
 
 
 class Grout(ThermalProperty):
@@ -127,4 +103,4 @@ class Soil(ThermalProperty):
         return output
 
     def to_input(self) -> dict:
-        return {"conductivity": self.k, "rho_cp": self.rhoCp, "undisturbed_temp": self.ugt}
+        return {"conductivity": self.k, "rho_cp": self.rho_cp, "undisturbed_temp": self.ugt}

--- a/ghedesigner/media.py
+++ b/ghedesigner/media.py
@@ -1,41 +1,94 @@
-from dataclasses import InitVar, asdict, dataclass, field
-
-from pygfunction.media import Fluid
+from scp.ethyl_alcohol import EthylAlcohol
+from scp.ethylene_glycol import EthyleneGlycol
+from scp.methyl_alcohol import MethylAlcohol
+from scp.propylene_glycol import PropyleneGlycol
+from scp.water import Water
 
 from ghedesigner.enums import FluidType
 
 
-@dataclass
-class GHEFluid(Fluid):
-    fluid_str: InitVar[str]
-    percent: InitVar[float]
-    temperature: float = 20.0
-    concentration_percent: float = field(init=False)
-    fluid_type: FluidType = field(init=False)
-
-    def __post_init__(self, fluid_str: str, percent: float) -> None:
-        fluid_type_map = {
-            FluidType.ETHYLALCOHOL.name: (FluidType.ETHYLALCOHOL, "MEA"),
-            FluidType.ETHYLENEGLYCOL.name: (FluidType.ETHYLENEGLYCOL, "MEG"),
-            FluidType.METHYLALCOHOL.name: (FluidType.METHYLALCOHOL, "MMA"),
-            FluidType.PROPYLENEGLYCOL.name: (FluidType.PROPYLENEGLYCOL, "MPG"),
-            FluidType.WATER.name: (FluidType.WATER, "WATER"),
-        }
-
+class Fluid:
+    def __init__(self, fluid_name: str, temperature: float = 20, percent: float = 0) -> None:
+        self.name = fluid_name
+        self.fluid_type = self.get_fluid_type(fluid_name)
+        self.temperature = temperature
         self.concentration_percent = percent
 
-        try:
-            self.fluid_type, fluid_shorthand = fluid_type_map[fluid_str.upper()]
-        except KeyError:
-            raise ValueError(f'FluidType "{fluid_str}" not implemented')
+        concentration_frac = self.concentration_percent / 100
+        if self.fluid_type == FluidType.ETHYLALCOHOL:
+            self._fluid = EthylAlcohol(concentration_frac)
+        elif self.fluid_type == FluidType.ETHYLENEGLYCOL:
+            self._fluid = EthyleneGlycol(concentration_frac)
+        elif self.fluid_type == FluidType.METHYLALCOHOL:
+            self._fluid = MethylAlcohol(concentration_frac)
+        elif self.fluid_type == FluidType.PROPYLENEGLYCOL:
+            self._fluid = PropyleneGlycol(concentration_frac)
+        elif self.fluid_type == FluidType.WATER:
+            self._fluid = Water()
 
-        super().__init__(fluid_shorthand, percent, self.temperature)
+    @staticmethod
+    def get_fluid_type(fluid_name: str) -> FluidType:
+        fluid_name_upper = fluid_name.upper()
+        if fluid_name_upper in ["MEA", "ETHYLALCOHOL", "ETHYL ALCOHOL"]:
+            return FluidType.ETHYLALCOHOL
+        if fluid_name_upper in ["MEG", "ETHYLENEGLYCOL", "ETHYLENE GLYCOL"]:
+            return FluidType.ETHYLENEGLYCOL
+        if fluid_name_upper in ["MMA", "METHYLALCOHOL", "METHYL ALCOHOL"]:
+            return FluidType.METHYLALCOHOL
+        if fluid_name_upper in ["MPG", "PROPYLENEGLYCOL", "PROPYLENE GLYCOL"]:
+            return FluidType.PROPYLENEGLYCOL
+        if fluid_name_upper == "WATER":
+            return FluidType.WATER
 
-    def to_input(self) -> dict:
-        return {
-            **asdict(self, dict_factory=lambda d: {k: v for k, v in d if k not in {"fluid_type"}}),
-            "fluid_name": self.fluid_type.name,
-        }
+        raise ValueError(f'Unsupported fluid type "{fluid_name}"')
+
+    @property
+    def cp(self) -> float:
+        return self._fluid.cp(self.temperature)
+
+    @property
+    def rho(self) -> float:
+        return self._fluid.rho(self.temperature)
+
+    @property
+    def mu(self) -> float:
+        return self._fluid.mu(self.temperature)
+
+    @property
+    def k(self) -> float:
+        return self._fluid.k(self.temperature)
+
+    @property
+    def rhoCp(self) -> float:
+        return self.rho * self.cp
+
+    @property
+    def alpha(self) -> float:
+        return self.k / self.rhoCp
+
+    # def __post_init__(self, fluid_str: str, percent: float) -> None:
+    #     fluid_type_map = {
+    #         FluidType.ETHYLALCOHOL.name: (FluidType.ETHYLALCOHOL, "MEA"),
+    #         FluidType.ETHYLENEGLYCOL.name: (FluidType.ETHYLENEGLYCOL, "MEG"),
+    #         FluidType.METHYLALCOHOL.name: (FluidType.METHYLALCOHOL, "MMA"),
+    #         FluidType.PROPYLENEGLYCOL.name: (FluidType.PROPYLENEGLYCOL, "MPG"),
+    #         FluidType.WATER.name: (FluidType.WATER, "WATER"),
+    #     }
+    #
+    #     self.concentration_percent = percent
+    #
+    #     try:
+    #         self.fluid_type, fluid_shorthand = fluid_type_map[fluid_str.upper()]
+    #     except KeyError:
+    #         raise ValueError(f'FluidType "{fluid_str}" not implemented')
+    #
+    #     super().__init__(fluid_shorthand, percent, self.temperature)
+    #
+    # def to_input(self) -> dict:
+    #     return {
+    #         **asdict(self, dict_factory=lambda d: {k: v for k, v in d if k not in {"fluid_type"}}),
+    #         "fluid_name": self.fluid_type.name,
+    #     }
 
 
 class ThermalProperty:

--- a/ghedesigner/output.py
+++ b/ghedesigner/output.py
@@ -315,10 +315,10 @@ class OutputManager:
             o += self.d_row(width, "Inner Pipe Thermal Conductivity, W/m-K:", ghe.bhe.pipe.k[0], f_3f, n_tabs=1)
             o += self.d_row(width, "Outer Pipe Thermal Conductivity, W/m-K:", ghe.bhe.pipe.k[1], f_3f, n_tabs=1)
 
-        o += self.d_row(width, "Pipe Volumetric Heat Capacity, kJ/m3-K:", ghe.bhe.pipe.rhoCp / 1000, f_2f, n_tabs=1)
+        o += self.d_row(width, "Pipe Volumetric Heat Capacity, kJ/m3-K:", ghe.bhe.pipe.rho_cp / 1000, f_2f, n_tabs=1)
         o += self.d_row(width, "Shank Spacing, mm:", ghe.bhe.pipe.s * 1000, f_2f, n_tabs=1)
         o += self.d_row(width, "Grout Thermal Conductivity, W/(m-K):", ghe.bhe.grout.k, f_3f, n_tabs=1)
-        o += self.d_row(width, "Grout Volumetric Heat Capacity, kJ/m3-K:", ghe.bhe.grout.rhoCp / 1000, f_2f, n_tabs=1)
+        o += self.d_row(width, "Grout Volumetric Heat Capacity, kJ/m3-K:", ghe.bhe.grout.rho_cp / 1000, f_2f, n_tabs=1)
         if isinstance(ghe.bhe.pipe.r_out, float):
             o += self.d_row(
                 width,
@@ -352,11 +352,11 @@ class OutputManager:
 
         o += "Soil Properties: " + "\n"
         o += self.d_row(width, "Thermal Conductivity, W/m-K:", ghe.bhe.soil.k, f_3f, n_tabs=1)
-        o += self.d_row(width, "Volumetric Heat Capacity, kJ/m3-K:", ghe.bhe.soil.rhoCp / 1000, f_2f, n_tabs=1)
+        o += self.d_row(width, "Volumetric Heat Capacity, kJ/m3-K:", ghe.bhe.soil.rho_cp / 1000, f_2f, n_tabs=1)
         o += self.d_row(width, "Undisturbed Ground Temperature, C:", ghe.bhe.soil.ugt, f_2f, n_tabs=1)
 
         o += "Fluid Properties" + "\n"
-        o += self.d_row(width, "Volumetric Heat Capacity, kJ/m3-K:", ghe.bhe.fluid.rhoCp / 1000, f_2f, n_tabs=1)
+        o += self.d_row(width, "Volumetric Heat Capacity, kJ/m3-K:", ghe.bhe.fluid.rho_cp / 1000, f_2f, n_tabs=1)
         o += self.d_row(width, "Thermal Conductivity, W/m-K:", ghe.bhe.fluid.k, f_2f, n_tabs=1)
         o += self.d_row(width, "Viscosity, Pa-s:", ghe.bhe.fluid.mu, f_sci, n_tabs=1)
         o += self.d_row(width, "Fluid Mix:", ghe.bhe.fluid.name, f_str, n_tabs=1)
@@ -582,16 +582,16 @@ class OutputManager:
                 "pipe_geometry": pipe_geometry,
                 "pipe_roughness": add_with_units(ghe.bhe.pipe.roughness, "m"),
                 "pipe_thermal_conductivity": add_with_units(ghe.bhe.pipe.k, "W/m-K"),
-                "pipe_volumetric_heat_capacity": add_with_units(ghe.bhe.pipe.rhoCp / 1000, "kJ/m3-K"),
+                "pipe_volumetric_heat_capacity": add_with_units(ghe.bhe.pipe.rho_cp / 1000, "kJ/m3-K"),
                 "grout_thermal_conductivity": add_with_units(ghe.bhe.grout.k, "W/m-K"),
-                "grout_volumetric_heat_capacity": add_with_units(ghe.bhe.grout.rhoCp / 1000, "kJ/m3-K"),
+                "grout_volumetric_heat_capacity": add_with_units(ghe.bhe.grout.rho_cp / 1000, "kJ/m3-K"),
                 "reynolds_number": reynolds,
                 "effective_borehole_resistance": add_with_units(ghe.bhe.calc_effective_borehole_resistance(), "W/m-K"),
                 # TODO: are the units right here?
                 "soil_thermal_conductivity": add_with_units(ghe.bhe.soil.k, "W/m-K"),
-                "soil_volumetric_heat_capacity": add_with_units(ghe.bhe.soil.rhoCp / 1000, "kJ/m3-K"),
+                "soil_volumetric_heat_capacity": add_with_units(ghe.bhe.soil.rho_cp / 1000, "kJ/m3-K"),
                 "soil_undisturbed_ground_temp": add_with_units(ghe.bhe.soil.ugt, "C"),
-                "fluid_volumetric_heat_capacity": add_with_units(ghe.bhe.fluid.rhoCp / 1000, "kJ/m3-K"),
+                "fluid_volumetric_heat_capacity": add_with_units(ghe.bhe.fluid.rho_cp / 1000, "kJ/m3-K"),
                 "fluid_thermal_conductivity": add_with_units(ghe.bhe.fluid.k, "W/m-K"),
                 "fluid_viscosity": add_with_units(ghe.bhe.fluid.mu, "Pa-s"),
                 "fluid_mixture": ghe.bhe.fluid.name,

--- a/ghedesigner/output.py
+++ b/ghedesigner/output.py
@@ -358,8 +358,8 @@ class OutputManager:
         o += "Fluid Properties" + "\n"
         o += self.d_row(width, "Volumetric Heat Capacity, kJ/m3-K:", ghe.bhe.fluid.rhoCp / 1000, f_2f, n_tabs=1)
         o += self.d_row(width, "Thermal Conductivity, W/m-K:", ghe.bhe.fluid.k, f_2f, n_tabs=1)
-        o += self.d_row(width, "Viscosity, Pa-s:", ghe.bhe.fluid.dynamic_viscosity(), f_sci, n_tabs=1)
-        o += self.d_row(width, "Fluid Mix:", ghe.bhe.fluid.fluid.fluid_name, f_str, n_tabs=1)
+        o += self.d_row(width, "Viscosity, Pa-s:", ghe.bhe.fluid.mu, f_sci, n_tabs=1)
+        o += self.d_row(width, "Fluid Mix:", ghe.bhe.fluid.name, f_str, n_tabs=1)
         o += self.d_row(width, "Density, kg/m^3:", ghe.bhe.fluid.rho, f_2f, n_tabs=1)
         o += self.d_row(width, "Mass Flow Rate Per Borehole, kg/s:", ghe.bhe.m_flow_borehole, f_3f, n_tabs=1)
         if hasattr(ghe.bhe, "h_f"):
@@ -593,8 +593,8 @@ class OutputManager:
                 "soil_undisturbed_ground_temp": add_with_units(ghe.bhe.soil.ugt, "C"),
                 "fluid_volumetric_heat_capacity": add_with_units(ghe.bhe.fluid.rhoCp / 1000, "kJ/m3-K"),
                 "fluid_thermal_conductivity": add_with_units(ghe.bhe.fluid.k, "W/m-K"),
-                "fluid_viscosity": add_with_units(ghe.bhe.fluid.dynamic_viscosity(), "Pa-s"),
-                "fluid_mixture": ghe.bhe.fluid.fluid.fluid_name,  # TODO: Is this the right lookup!?!?!? :)
+                "fluid_viscosity": add_with_units(ghe.bhe.fluid.mu, "Pa-s"),
+                "fluid_mixture": ghe.bhe.fluid.name,
                 "fluid_density": add_with_units(ghe.bhe.fluid.rho, "kg/m3"),
                 "fluid_mass_flow_rate_per_borehole": add_with_units(ghe.bhe.m_flow_borehole, "kg/s"),
             },

--- a/ghedesigner/tests/test_compute_bh_resistance.py
+++ b/ghedesigner/tests/test_compute_bh_resistance.py
@@ -4,7 +4,7 @@ from ghedesigner.ghe.boreholes.core import Borehole
 from ghedesigner.ghe.boreholes.multi_u_borehole import MultipleUTube
 from ghedesigner.ghe.boreholes.single_u_borehole import SingleUTube
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.tests.test_base_case import GHEBaseTest
 
 
@@ -54,7 +54,7 @@ class TestBHResistance(GHEBaseTest):
         grout = Grout(k_g, rho_cp_g)
 
         # Fluid properties
-        fluid = GHEFluid(fluid_str="Water", percent=0.0)
+        fluid = Fluid(fluid_name="Water", percent=0.0)
         v_flow_borehole = 0.8  # Volumetric flow rate per borehole (L/s)
         # Total fluid mass flow rate per borehole (kg/s)
         m_flow_borehole = v_flow_borehole / 1000.0 * fluid.rho
@@ -103,7 +103,7 @@ class TestBHResistance(GHEBaseTest):
         grout = Grout(k_g, rho_cp_g)
 
         # fluid
-        fluid = GHEFluid(fluid_str="Water", percent=0.0)
+        fluid = Fluid(fluid_name="Water", percent=0.0)
 
         # U-tubes
         v_flow_borehole = 0.2  # volumetric flow rate per borehole (L/s)
@@ -175,7 +175,7 @@ class TestBHResistance(GHEBaseTest):
         grout = Grout(k_g, rho_cp_g)
 
         # Fluid properties
-        fluid = GHEFluid(fluid_str="Water", percent=0.0)
+        fluid = Fluid(fluid_name="Water", percent=0.0)
         v_flow_borehole = 0.2  # Volumetric flow rate per borehole (L/s)
         # Total fluid mass flow rate per borehole (kg/s)
         m_flow_borehole = v_flow_borehole / 1000.0 * fluid.rho
@@ -244,7 +244,7 @@ class TestBHResistance(GHEBaseTest):
         grout = Grout(k_g, rho_cp_g)
 
         # Fluid properties
-        fluid = GHEFluid(fluid_str="Water", percent=0.0)
+        fluid = Fluid(fluid_name="Water", percent=0.0)
 
         # A list of volumetric flow rates to check borehole resistances for (L/s)
         v_flow_rates = [0.3, 0.2, 0.18, 0.15, 0.12, 0.1, 0.08, 0.07, 0.06, 0.05]

--- a/ghedesigner/tests/test_compute_live_g_function_sim_and_size.py
+++ b/ghedesigner/tests/test_compute_live_g_function_sim_and_size.py
@@ -4,7 +4,7 @@ from ghedesigner.ghe.coordinates import rectangle
 from ghedesigner.ghe.gfunction import calc_g_func_for_multiple_lengths
 from ghedesigner.ghe.ground_heat_exchangers import GHE
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.tests.test_base_case import GHEBaseTest
 from ghedesigner.utilities import eskilson_log_times
 
@@ -57,7 +57,7 @@ class TestLiveGFunctionSimAndSize(GHEBaseTest):
         # Inputs related to fluid
         # -----------------------
         # Fluid properties
-        fluid = GHEFluid(fluid_str="Water", percent=0.0)
+        fluid = Fluid(fluid_name="Water", percent=0.0)
 
         # Coordinates
         nx = 12

--- a/ghedesigner/tests/test_equiv_pipes.py
+++ b/ghedesigner/tests/test_equiv_pipes.py
@@ -2,7 +2,7 @@ from ghedesigner.ghe.boreholes.coaxial_borehole import CoaxialPipe
 from ghedesigner.ghe.boreholes.core import Borehole
 from ghedesigner.ghe.boreholes.multi_u_borehole import MultipleUTube
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.tests.test_base_case import GHEBaseTest
 
 
@@ -39,7 +39,7 @@ class TestEquivalentPipes(GHEBaseTest):
         grout = Grout(k_g, rho_cp_g)
 
         # Fluid properties
-        fluid = GHEFluid(fluid_str="Water", percent=0.0)
+        fluid = Fluid(fluid_name="Water", percent=0.0)
         v_flow_borehole = 0.8  # Volumetric flow rate per borehole (L/s)
         # Total fluid mass flow rate per borehole (kg/s)
         m_flow_borehole = v_flow_borehole / 1000.0 * fluid.rho
@@ -113,7 +113,7 @@ class TestEquivalentPipes(GHEBaseTest):
         grout = Grout(k_g, rho_cp_g)
 
         # Fluid properties
-        fluid = GHEFluid(fluid_str="Water", percent=0.0)
+        fluid = Fluid(fluid_name="Water", percent=0.0)
         v_flow_borehole = 0.5  # Volumetric flow rate per borehole (L/s)
         # Total fluid mass flow rate per borehole (kg/s)
         m_flow_borehole = v_flow_borehole / 1000.0 * fluid.rho

--- a/ghedesigner/tests/test_find_design_bi_rectangle.py
+++ b/ghedesigner/tests/test_find_design_bi_rectangle.py
@@ -8,14 +8,14 @@ from ghedesigner.enums import TimestepType
 from ghedesigner.ghe.boreholes.core import Borehole
 from ghedesigner.ghe.design.birectangle import DesignBiRectangle, GeometricConstraintsBiRectangle
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.tests.test_base_case import GHEBaseTest
 
 
 class TestFindBiRectangleDesign(GHEBaseTest):
     def get_design(self, pipe: Pipe, flow_rate: float):
         soil = Soil(k=2.0, rho_cp=2343493.0, ugt=18.3)
-        fluid = GHEFluid("water", 0.0, 20.0)
+        fluid = Fluid("water")
         grout = Grout(1.0, 3901000.0)
         ground_loads = self.get_atlanta_loads()
         borehole = Borehole(burial_depth=2.0, borehole_radius=0.07)

--- a/ghedesigner/tests/test_find_design_bi_rectangle_constrained.py
+++ b/ghedesigner/tests/test_find_design_bi_rectangle_constrained.py
@@ -11,7 +11,7 @@ from ghedesigner.ghe.design.birectangle_constrained import (
     GeometricConstraintsBiRectangleConstrained,
 )
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.tests.test_base_case import GHEBaseTest
 
 prop_boundary = [
@@ -75,7 +75,7 @@ class TestFindBiRectangleConstrainedDesign(GHEBaseTest):
         _no_go_boundaries: list[list[list[float]]],
     ):
         soil = Soil(k=2.0, rho_cp=2343493.0, ugt=18.3)
-        fluid = GHEFluid("water", 0.0, 20.0)
+        fluid = Fluid("water")
         grout = Grout(1.0, 3901000.0)
         ground_loads = self.get_atlanta_loads()
         borehole = Borehole(burial_depth=2.0, borehole_radius=borehole_radius)

--- a/ghedesigner/tests/test_find_design_bi_zoned_rectangle.py
+++ b/ghedesigner/tests/test_find_design_bi_zoned_rectangle.py
@@ -8,7 +8,7 @@ from ghedesigner.enums import TimestepType
 from ghedesigner.ghe.boreholes.core import Borehole
 from ghedesigner.ghe.design.bizoned import DesignBiZoned, GeometricConstraintsBiZoned
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.tests.test_base_case import GHEBaseTest
 
 # This file contains three examples utilizing the bi-zoned rectangle design algorithm for a single U, double U,
@@ -18,7 +18,7 @@ from ghedesigner.tests.test_base_case import GHEBaseTest
 class TestFindBiZonedRectangleDesign(GHEBaseTest):
     def get_design(self, pipe: Pipe, flow_rate: float):
         soil = Soil(k=2.0, rho_cp=2343493.0, ugt=18.3)
-        fluid = GHEFluid("water", 0.0, 20.0)
+        fluid = Fluid("water")
         grout = Grout(1.0, 3901000.0)
         ground_loads = self.get_atlanta_loads()
         borehole = Borehole(burial_depth=2.0, borehole_radius=0.07)

--- a/ghedesigner/tests/test_find_design_near_square.py
+++ b/ghedesigner/tests/test_find_design_near_square.py
@@ -8,7 +8,7 @@ from ghedesigner.enums import FlowConfigType, TimestepType
 from ghedesigner.ghe.boreholes.core import Borehole
 from ghedesigner.ghe.design.near_square import DesignNearSquare, GeometricConstraintsNearSquare
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.tests.test_base_case import GHEBaseTest
 from ghedesigner.utilities import length_of_side
 
@@ -23,7 +23,7 @@ class TestFindNearSquareDesign(GHEBaseTest):
     ):
         soil = Soil(k=2.0, rho_cp=2343493.0, ugt=18.3)
         grout = Grout(k=1.0, rho_cp=3901000.0)
-        fluid = GHEFluid(fluid_str="water", percent=0.0, temperature=20.0)
+        fluid = Fluid(fluid_name="water", percent=0.0, temperature=20.0)
         borehole = Borehole(burial_depth=2.0, borehole_radius=0.07)
         ground_loads = self.get_atlanta_loads()
         b = 5.0

--- a/ghedesigner/tests/test_find_design_near_square_multiyear.py
+++ b/ghedesigner/tests/test_find_design_near_square_multiyear.py
@@ -7,7 +7,7 @@ from ghedesigner.enums import TimestepType
 from ghedesigner.ghe.boreholes.core import Borehole
 from ghedesigner.ghe.design.near_square import DesignNearSquare, GeometricConstraintsNearSquare
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.tests.test_base_case import GHEBaseTest
 
 
@@ -18,7 +18,7 @@ class TestFindNearSquareMultiyearDesign(GHEBaseTest):
     def get_design(self, pipe: Pipe, flow_rate: float):
         soil = Soil(k=2.0, rho_cp=2343493.0, ugt=18.3)
         grout = Grout(k=1.0, rho_cp=3901000.0)
-        fluid = GHEFluid(fluid_str="water", percent=0.0, temperature=20.0)
+        fluid = Fluid(fluid_name="water", percent=0.0, temperature=20.0)
         borehole = Borehole(burial_depth=2.0, borehole_radius=0.07)
         ground_loads = self.get_multiyear_loads()
         b = 5.0

--- a/ghedesigner/tests/test_find_design_rectangle.py
+++ b/ghedesigner/tests/test_find_design_rectangle.py
@@ -2,13 +2,13 @@ from ghedesigner.enums import TimestepType
 from ghedesigner.ghe.boreholes.core import Borehole
 from ghedesigner.ghe.design.rectangle import DesignRectangle, GeometricConstraintsRectangle
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.tests.test_base_case import GHEBaseTest
 
 
 class TestFindRectangleDesign(GHEBaseTest):
     def get_design(self, pipe: Pipe, flow_rate: float):
-        fluid = GHEFluid("water", 0.0, 20.0)
+        fluid = Fluid("water")
         grout = Grout(1.0, 3901000.0)
         soil = Soil(2.0, 2343493.0, 18.3)
         ground_loads = self.get_atlanta_loads()

--- a/ghedesigner/tests/test_find_design_rowwise.py
+++ b/ghedesigner/tests/test_find_design_rowwise.py
@@ -6,7 +6,7 @@ from ghedesigner.ghe.boreholes.core import Borehole
 from ghedesigner.ghe.design.rowwise import DesignRowWise, GeometricConstraintsRowWise
 from ghedesigner.ghe.ground_heat_exchangers import GHE
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.tests.test_base_case import GHEBaseTest
 
 prop_boundary = [
@@ -58,7 +58,7 @@ class TestFindRowWiseDesign(GHEBaseTest):
     # design interface with a single U-tube borehole heat exchanger.
     def get_design(self, pipe: Pipe, flow_rate: float, spacing_ratio: float | None = None):
         soil = Soil(k=2.0, rho_cp=2343493.0, ugt=18.3)
-        fluid = GHEFluid("water", 0.0, 20.0)
+        fluid = Fluid("water")
         grout = Grout(1.0, 3901000.0)
         ground_loads = self.get_atlanta_loads()
         borehole = Borehole(burial_depth=2.0, borehole_radius=0.07)

--- a/ghedesigner/tests/test_loads.py
+++ b/ghedesigner/tests/test_loads.py
@@ -3,7 +3,7 @@ from ghedesigner.ghe.boreholes.core import Borehole
 from ghedesigner.ghe.design.rectangle import DesignRectangle, GeometricConstraintsRectangle
 from ghedesigner.ghe.pipe import Pipe
 from ghedesigner.ghe.search.bisection_1d import Bisection1D
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.tests.test_base_case import GHEBaseTest
 
 
@@ -22,7 +22,7 @@ class TestLoads(GHEBaseTest):
             shank_spacing=0.01856,
             roughness=1.0e-6,
         )
-        fluid = GHEFluid("water", 0.0, 20.0)
+        fluid = Fluid("water")
         grout = Grout(1.0, 3901000.0)
         soil = Soil(2.0, 2343493.0, 18.3)
         borehole = Borehole(burial_depth=2.0, borehole_radius=0.07)

--- a/ghedesigner/tests/test_new_workflow.py
+++ b/ghedesigner/tests/test_new_workflow.py
@@ -6,7 +6,7 @@ from ghedesigner.ghe.boreholes.core import Borehole
 from ghedesigner.ghe.design.rectangle import DesignRectangle, GeometricConstraintsRectangle
 from ghedesigner.ghe.pipe import Pipe
 from ghedesigner.heat_pump import HeatPump
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.system import System
 from ghedesigner.tests.test_base_case import GHEBaseTest
 
@@ -37,7 +37,7 @@ class TestNewWorkflows(GHEBaseTest):
             rho_cp=1542000.0,
         )
         soil = Soil(k=2.0, rho_cp=2343493.0, ugt=18.3)
-        fluid = GHEFluid("water", 0.0, 20.0)
+        fluid = Fluid("water")
         grout = Grout(1.0, 3901000.0)
         ground_loads = self.get_atlanta_loads()
         borehole = Borehole(burial_depth=2.0, borehole_radius=0.07)

--- a/ghedesigner/tests/test_radial_numerical_borehole.py
+++ b/ghedesigner/tests/test_radial_numerical_borehole.py
@@ -3,12 +3,12 @@ import unittest
 from ghedesigner.ghe.boreholes.core import Borehole
 from ghedesigner.ghe.boreholes.single_u_borehole import SingleUTube
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 
 
 class TestRadialNumericalBorehole(unittest.TestCase):
     def test_calc_sts_g_functions(self):
-        fluid = GHEFluid(fluid_str="WATER", percent=0)
+        fluid = Fluid(fluid_name="WATER", percent=0)
         borehole = Borehole(burial_depth=2.0, borehole_radius=0.075)
         grout = Grout(k=2.0, rho_cp=2000000.0)
 

--- a/ghedesigner/tests/test_simulate_ghe.py
+++ b/ghedesigner/tests/test_simulate_ghe.py
@@ -4,7 +4,7 @@ from ghedesigner.ghe.coordinates import rectangle
 from ghedesigner.ghe.gfunction import calc_g_func_for_multiple_lengths
 from ghedesigner.ghe.ground_heat_exchangers import GHE
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.tests.test_base_case import GHEBaseTest
 from ghedesigner.utilities import eskilson_log_times
 
@@ -101,7 +101,7 @@ class TestGHE(GHEBaseTest):
 
         # -----------------------
         # Fluid properties
-        self.fluid = GHEFluid(fluid_str="Water", percent=0.0)
+        self.fluid = Fluid(fluid_name="Water", percent=0.0)
         # System volumetric flow rate (L/s)
         self.v_flow_system = v_flow_borehole * float(nx * ny)
         # Total fluid mass flow rate per borehole (kg/s)

--- a/ghedesigner/tests/test_size_limits.py
+++ b/ghedesigner/tests/test_size_limits.py
@@ -2,7 +2,7 @@ from ghedesigner.enums import TimestepType
 from ghedesigner.ghe.boreholes.core import Borehole
 from ghedesigner.ghe.design.near_square import DesignNearSquare, GeometricConstraintsNearSquare
 from ghedesigner.ghe.pipe import Pipe
-from ghedesigner.media import GHEFluid, Grout, Soil
+from ghedesigner.media import Fluid, Grout, Soil
 from ghedesigner.tests.test_base_case import GHEBaseTest
 
 
@@ -21,7 +21,7 @@ class TestFindNearSquareDesign(GHEBaseTest):
 
     def test_small_loads(self):
         pipe = self.get_pipe()
-        fluid = GHEFluid("water", 0.0, 20.0)
+        fluid = Fluid("water")
         grout = Grout(1.0, 3901000.0)
         soil = Soil(3.493, 2.5797e06, 10.0)
         ground_loads = [1.0e2] * 8760
@@ -54,7 +54,7 @@ class TestFindNearSquareDesign(GHEBaseTest):
 
     def test_big_loads(self):
         pipe = self.get_pipe()
-        fluid = GHEFluid("water", 0.0, 20.0)
+        fluid = Fluid("water")
         grout = Grout(1.0, 3901000.0)
         soil = Soil(3.493, 2.5797e06, 10.0)
         ground_loads = [1.0e6] * 8760
@@ -87,7 +87,7 @@ class TestFindNearSquareDesign(GHEBaseTest):
 
     def test_big_loads_with_max_boreholes(self):
         pipe = self.get_pipe()
-        fluid = GHEFluid("water", 0.0, 20.0)
+        fluid = Fluid("water")
         grout = Grout(1.0, 3901000.0)
         soil = Soil(3.493, 2.5797e06, 10.0)
         ground_loads = [1.0e6] * 8760

--- a/poetry.lock
+++ b/poetry.lock
@@ -1895,4 +1895,4 @@ viz = ["cartopy (>=0.23)", "matplotlib", "nc-time-axis", "seaborn"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.14"
-content-hash = "5128a5e3d8805272eab25d3e4652f7767f0d5fb601d40a4396a4f93b5f378899"
+content-hash = "d14ae57990e15720ab15663f2c4190edd83f0fac41a00fc31ad0c585a3337196"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ numpy = "^2.0.0"
 pygfunction = "^2.3.1"
 bhresist ="^0.2.0"
 scipy = "^1.14"
+secondarycoolantprops = "^1.3"
 
 [tool.poetry.group.dev.dependencies]
 mkdocs-material = "^9.5"


### PR DESCRIPTION
## Pull request overview

Our fluid object was relying and wrapping `pygfunction`'s fluid object, which was just relying on [SecondaryCoolantProps](https://pypi.org/project/SecondaryCoolantProps/). This just makes that dependency explicit on our end and cleans up a few things along the way.

### Checklist

- [ ] Documentation added/updated
- [ ] CI status: all green or justified
